### PR TITLE
Build linux_x86_64 in manylinux2014 container

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,10 @@ on: push
 jobs:
   test:
     runs-on: ${{ matrix.os }}
+    env:
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    container: ${{ matrix.os == 'ubuntu-latest' && 'quay.io/pypa/manylinux2014_x86_64:latest' || null }}
     strategy:
       matrix:
         rust: [stable]
@@ -18,7 +22,7 @@ jobs:
             target: "x86_64-unknown-linux-gnu"
     steps:
       - name: "Checkout Repo"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3.5.3
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,11 @@ jobs:
     steps:
       - name: "Checkout Repo"
         uses: actions/checkout@v3.5.3
+      - name: Install Rustup
+        run: |
+          curl --proto '=https' --tlsv1.2 --retry 10 --location --silent --show-error --fail "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        shell: bash
       - name: "Install Rust"
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,11 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3.5.3
+      - name: Install Rustup
+        run: |
+          curl --proto '=https' --tlsv1.2 --retry 10 --location --silent --show-error --fail "https://sh.rustup.rs" | sh -s -- --default-toolchain none -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        shell: bash
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,10 @@ on:
 jobs:
   release:
     runs-on: ${{matrix.os}}
+    env:
+      ACTIONS_RUNNER_FORCE_ACTIONS_NODE_VERSION: node16
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    container: ${{ matrix.os == 'ubuntu-latest' && 'quay.io/pypa/manylinux2014_x86_64:latest' || null }}
     strategy:
       matrix:
         rust: [stable]
@@ -30,7 +34,7 @@ jobs:
             target: "x86_64-unknown-linux-gnu"
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3.5.3
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
- use [manylinux2014](https://peps.python.org/pep-0599/) for improved compatibility, also see https://github.com/pypa/manylinux
- use node16 for CentOS7 compatibility (see https://github.com/actions/runner/issues/2906)
- install rustup in an extra step so we don't hit https://github.com/dtolnay/rust-toolchain/issues/122